### PR TITLE
Support building extension on both Python 2 and 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ __url__     = "http://amper.github.com/cityhash"
 from setuptools import setup
 from setuptools.extension import Extension
 from setuptools.dist import Distribution
-from pkg_resources import resource_string
 
 try:
     from Cython.Distutils import build_ext
@@ -60,6 +59,10 @@ else:
 VERSION = '0.1.7'
 URL = "https://github.com/escherba/python-cityhash"
 
+with open('README.rst', 'rb') as fd:
+    LONG_DESCRIPTION = fd.read().decode('utf-8')
+
+
 setup(
     version=VERSION,
     description="Python-bindings for CityHash, a fast non-cryptographic hash algorithm",
@@ -88,6 +91,6 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Utilities'
     ],
-    long_description=resource_string(__name__, 'README.rst'),
+    long_description=LONG_DESCRIPTION,
     distclass=BinaryDistribution,
 )

--- a/src/cityhash.pyx
+++ b/src/cityhash.pyx
@@ -55,9 +55,17 @@ from cpython.buffer cimport PyObject_GetBuffer
 from cpython.unicode cimport PyUnicode_Check
 from cpython.unicode cimport PyUnicode_AsUTF8String
 
-from cpython.string cimport PyString_Check
-from cpython.string cimport PyString_GET_SIZE
-from cpython.string cimport PyString_AS_STRING
+from sys import version_info
+
+if version_info[0] == 2:
+    from cpython.string cimport PyString_Check
+    from cpython.string cimport PyString_GET_SIZE
+    from cpython.string cimport PyString_AS_STRING
+else:
+    from cpython.bytes cimport PyBytes_Check as PyString_Check
+    from cpython.bytes cimport PyBytes_GET_SIZE as PyString_GET_SIZE
+    from cpython.bytes cimport PyBytes_AS_STRING as PyString_AS_STRING
+
 from cpython cimport Py_DECREF
 
 


### PR DESCRIPTION
* Slurps README.rst into a str instead of using pkg_resources'
  resource_string
* Replaces PyString_* calls with PyBytes_* under Python 3