### PR TITLE
handle exceptions from cpu_info so non-x86 and ARMs compile

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,13 @@ from setuptools import setup
 from setuptools.extension import Extension
 from setuptools.dist import Distribution
 from os.path import join, dirname
-from cpuinfo import get_cpu_info
 
-
-cpu_info = get_cpu_info()
-have_sse42 = 'sse4.2' in cpu_info['flags']
+try:
+    from cpuinfo import get_cpu_info
+    cpu_info = get_cpu_info()
+    have_sse42 = 'sse4.2' in cpu_info['flags']
+except Exception:
+    have_sse42 = False
 
 try:
     from Cython.Distutils import build_ext


### PR DESCRIPTION
cpu_info module used for sse42 support throws generic Exception on import on non-arms and non-x86s.

Those archs won't have sse42, so it should be safe to catch it and disable sse42 in setup.py.
